### PR TITLE
Improved PID bachelor selection in case of combined probability used

### DIFF
--- a/PWGHF/vertexingHF/macros/makeTFile4CutsLctoV0bachelor.C
+++ b/PWGHF/vertexingHF/macros/makeTFile4CutsLctoV0bachelor.C
@@ -333,10 +333,15 @@ void makeInputAliAnalysisTaskSELctoV0bachelor(){
 
   RDHFLctoV0An->SetCuts(nvars,nptbins,anacutsval);
 
+  RDHFLctoV0An->SetGetNTPCSigmaCutForPreselection(3);
+  const Int_t nBachelorPbins=2;
   if (RDHFLctoV0An->GetPidSelectionFlag()==9) {
-    Float_t minCombProb[nptbins];
-    for (Int_t iBin=0; iBin<nptbins; iBin++) minCombProb[iBin]=0.;
-    RDHFLctoV0An->SetMinCombinedProbability(nptbins,minCombProb);
+    Float_t minCombProb[nBachelorPbins];
+    for (Int_t iBin=0; iBin<nBachelorPbins; iBin++) minCombProb[iBin]=0.;
+    RDHFLctoV0An->SetMinCombinedProbability(nBachelorPbins,minCombProb);
+    Float_t bachelorPlimits[nBachelorPbins+];
+    for (Int_t iBin=0; iBin<nBachelorPbins; iBin++) bachelorPlimits[iBin]=0.;
+    SetBachelorPLimitsForPID(nBachelorPbins,bachelorPlimits);
   }
 
   //pid settings


### PR DESCRIPTION
Improved PID bachelor selection in case of combined probability used (fPidSelectionFlag==9)
Combined probability cut variable according to the bachelor momentum.
This change will affect only Lc->pK0S analyses(analyzers) that use the value 9 for the PID selection flag (AliRDHFCutsLctoV0::fPidSelectionFlag).
